### PR TITLE
fix: correct git clone URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ AIVA uses a layered architecture:
 
 ```bash
 # Clone the repository
-git clone https://github.com/aiva/aiva.git
+git clone https://github.com/tyrchen/aiva.git
 cd aiva
 
 # Build and install


### PR DESCRIPTION
Fixed the incorrect git clone URL from `https://github.com/aiva/aiva.git` to `https://github.com/tyrchen/aiva.git`